### PR TITLE
Specify the bevy_asset feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ manage_clipboard = ["arboard", "thread_local"]
 open_url = ["webbrowser"]
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", default-features = false, features = ["bevy_render", "bevy_core_pipeline"] }
+bevy = { git = "https://github.com/bevyengine/bevy", default-features = false, features = ["bevy_render", "bevy_core_pipeline", "bevy_asset"] }
 egui = { version = "0.18", features = ["bytemuck"] }
 webbrowser = { version = "0.7", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ manage_clipboard = ["arboard", "thread_local"]
 open_url = ["webbrowser"]
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", default-features = false, features = ["bevy_render", "bevy_core_pipeline", "bevy_asset"] }
+bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = ["bevy_render", "bevy_core_pipeline", "bevy_asset"] }
 egui = { version = "0.18", features = ["bytemuck"] }
 webbrowser = { version = "0.7", optional = true }
 
@@ -31,7 +31,7 @@ thread_local = { version = "1.1.0", optional = true }
 [dev-dependencies]
 once_cell = "1.9.0"
 version-sync = "0.9.2"
-bevy = { git = "https://github.com/bevyengine/bevy", default-features = false, features = [
+bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
     "x11",
     "png",
     "bevy_pbr",


### PR DESCRIPTION
The `main` branch of your repo targeting Bevy's `main` no longer compiles because of [this upstream commit](https://github.com/bevyengine/bevy/commit/231894a3a6ae57d50483ed51658e7c15c6122a63#diff-08e267b6e2b1454201274b80f74cbfaa49fe88021cf34f0aeff034162c1a1b56R15).

This PR adds the new feature specification needed to get things compiling again.

Thanks for helping to keep `bevy_egui` up to date :grin: 