### PR TITLE
Switch to Bevy 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ manage_clipboard = ["arboard", "thread_local"]
 open_url = ["webbrowser"]
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", default-features = false, features = ["bevy_render", "bevy_core_pipeline", "bevy_asset"] }
+bevy = { version = "0.8", default-features = false, features = ["bevy_render", "bevy_core_pipeline", "bevy_asset"] }
 egui = { version = "0.18", features = ["bytemuck"] }
 webbrowser = { version = "0.7", optional = true }
 
@@ -31,7 +31,7 @@ thread_local = { version = "1.1.0", optional = true }
 [dev-dependencies]
 once_cell = "1.9.0"
 version-sync = "0.9.2"
-bevy = { git = "https://github.com/bevyengine/bevy", default-features = false, features = [
+bevy = { version = "0.8", default-features = false, features = [
     "x11",
     "png",
     "bevy_pbr",


### PR DESCRIPTION
Bevy 0.8's officially out, can drop the Git dependency 🎉 