### PR TITLE
Set up primary window and get examples working

### DIFF
--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -27,10 +27,10 @@ fn main() {
         .init_resource::<UiState>()
         .add_plugins(DefaultPlugins)
         .add_plugin(EguiPlugin)
-        .add_startup_system(configure_visuals_system)
         .add_startup_system(configure_ui_state_system)
         .add_system(update_ui_scale_factor_system)
         .add_system(ui_example_system)
+        .add_system(configure_visuals_system)
         .run();
 }
 #[derive(Default, Resource)]
@@ -46,13 +46,17 @@ struct UiState {
 fn configure_visuals_system(
     mut egui_ctx: ResMut<EguiContext>,
     windows: Query<Entity, With<Window>>,
+    mut has_run: Local<bool>,
 ) {
-    egui_ctx
-        .ctx_for_window_mut(windows.iter().next().unwrap())
-        .set_visuals(egui::Visuals {
-            window_rounding: 0.0.into(),
-            ..Default::default()
-        });
+    if !*has_run {
+        egui_ctx
+            .ctx_for_window_mut(windows.iter().next().unwrap())
+            .set_visuals(egui::Visuals {
+                window_rounding: 0.0.into(),
+                ..Default::default()
+            });
+        *has_run = true;
+    }
 }
 
 fn configure_ui_state_system(mut ui_state: ResMut<UiState>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,15 +74,15 @@ use bevy::{
     input::InputSystem,
     log,
     prelude::{
-        Added, CoreSet, Deref, DerefMut, Entity, IntoSystemConfig, Query, Resource, Shader,
-        StartupSet, SystemSet, With,
+        CoreSet, Deref, DerefMut, Entity, IntoSystemConfig, Query, Resource, Shader, StartupSet,
+        SystemSet, With,
     },
     render::{
         render_graph::RenderGraph, render_resource::SpecializedRenderPipelines, texture::Image,
         Extract, ExtractSchedule, RenderApp, RenderSet,
     },
     utils::HashMap,
-    window::{PrimaryWindow, Window},
+    window::PrimaryWindow,
 };
 use egui_node::EguiNode;
 #[cfg(all(feature = "manage_clipboard", not(target_arch = "wasm32")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -512,7 +512,7 @@ impl Plugin for EguiPlugin {
                 .add_systems_to_schedule(
                     ExtractSchedule,
                     (
-                        set_up_primary_windows,
+                        setup_primary_window,
                         render_systems::extract_egui_render_data_system,
                         render_systems::extract_egui_textures_system,
                     ),
@@ -526,19 +526,21 @@ impl Plugin for EguiPlugin {
     }
 }
 
-fn set_up_primary_windows(
+fn setup_primary_window(
     primary_window: Extract<Query<Entity, With<PrimaryWindow>>>,
     mut render_graph: ResMut<RenderGraph>,
 ) {
-    // NOTE: This is all getting called every time!
-    let window = primary_window.get_single().unwrap();
-    setup_pipeline(
-        &mut render_graph,
-        RenderGraphConfig {
-            window,
-            egui_pass: node::EGUI_PASS,
-        },
-    );
+    if let Ok(window_entity) = primary_window.get_single() {
+        if render_graph.get_node::<EguiNode>(node::EGUI_PASS).is_err() {
+            setup_pipeline(
+                &mut render_graph,
+                RenderGraphConfig {
+                    window: window_entity,
+                    egui_pass: node::EGUI_PASS,
+                },
+            );
+        }
+    }
 }
 
 /// Contains textures allocated and painted by Egui.


### PR DESCRIPTION
Adds a new system to Bevy's render app to set up the primary window. As-is, this will need more since it's setting up the pipeline every time it's called, but it gets Egui rendering again.

I also removed the node edge with `ui_pass_driver` since it doesn't exist anymore. It seems to work for me, but I can't make any guarantees on that. 